### PR TITLE
ci: add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,69 @@
+name: Publish to PyPI
+
+#checkov:skip=CKV_GHA_7:tag input is validated against existing GitHub releases via `gh release view` before checkout, cannot reference arbitrary refs
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (defaults to latest release if omitted)'
+        required: false
+        type: string
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Resolve release tag
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG_INPUT: ${{ inputs.tag }}
+      run: |
+        if [ -n "$TAG_INPUT" ]; then
+          tag="$TAG_INPUT"
+          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null
+        else
+          tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+        fi
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+    - uses: actions/checkout@master
+      with:
+        ref: ${{ steps.release.outputs.tag }}
+    - name: Set up Python
+      uses: actions/setup-python@master
+      with:
+        python-version: '3.12'
+    - name: Install uv
+      run: pip install uv
+    - name: Build distributions
+      run: uv build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: dist
+        path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-unified-signals
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@master
+      with:
+        name: dist
+        path: dist/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ version_toml = ["pyproject.toml:project.version"]
 tag_format = "{version}"
 major_on_zero = false
 allow_zero_version = true
-build_command = ""
+build_command = "uv lock --upgrade-package django-unified-signals"
+assets = ["uv.lock"]
 commit_message = "chore(release): {version}"
 
 [tool.semantic_release.branches.main]

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "django-unified-signals"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary
- Mirrors publish-testpypi.yaml: build/publish split, trusted publishing (OIDC), manual workflow_dispatch with tag resolution
- Publishes to real PyPI (no repository-url override)
- `pypi` environment gated by required reviewer approval (irreversible, unlike testpypi)