### PR TITLE
fix: move uv.lock sync out of psr build_command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,3 +28,26 @@ jobs:
         github_token: ${{ secrets.RELEASE_TOKEN }}
         git_committer_name: "github-actions[bot]"
         git_committer_email: "github-actions[bot]@users.noreply.github.com"
+
+    - name: Set up Python
+      uses: actions/setup-python@master
+      with:
+        python-version: '3.12'
+
+    - name: Install uv
+      run: pip install uv
+
+    - name: Sync uv.lock version
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      run: |
+        uv lock --upgrade-package django-unified-signals
+        if git diff --quiet -- uv.lock; then
+          echo "uv.lock already in sync"
+          exit 0
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add uv.lock
+        git commit -m "chore: sync uv.lock version"
+        git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,7 @@ version_toml = ["pyproject.toml:project.version"]
 tag_format = "{version}"
 major_on_zero = false
 allow_zero_version = true
-build_command = "uv lock --upgrade-package django-unified-signals"
-assets = ["uv.lock"]
+build_command = ""
 commit_message = "chore(release): {version}"
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
## Summary
- Previous fix (#25) ran `uv lock` via psr's `build_command`, but that runs inside psr's own docker image which has no `uv` — release run failed with "uv: command not found"
- Revert `build_command`/`assets` in pyproject.toml
- Instead, sync `uv.lock` as a plain runner step after the psr action, pushing a follow-up commit with `RELEASE_TOKEN` if the lockfile changed