### PR TITLE
fix: forward message kwarg in send_robust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,12 @@ jobs:
       run: pip install tox uv
     - name: Run check
       run: tox -e ${{ matrix.check }}
+    - name: Upload coverage to Codecov
+      if: matrix.check == 'coverage'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Django Unified Signals
 
 [![Continuous Integration](https://github.com/ivellios/django-unified-signals/actions/workflows/ci.yaml/badge.svg)](https://github.com/ivellios/django-unified-signals/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/ivellios/django-unified-signals/branch/master/graph/badge.svg)](https://codecov.io/gh/ivellios/django-unified-signals)
 
 This package extends behavior of the Django Signals, by unifying the data passed
 when the signal is sent. That way both: the sender and the receiver can be sure 

--- a/src/unified_signals/signals.py
+++ b/src/unified_signals/signals.py
@@ -57,4 +57,4 @@ class UnifiedSignal(Signal):
         **named: typing.Any,
     ):
         self._check_message_class(message)
-        return super().send_robust(sender, **named)
+        return super().send_robust(sender, message=message, **named)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -19,7 +19,8 @@ class SenderMock:
 
 
 def test_event_signal():
-    UnifiedSignal(DataMock)
+    signal = UnifiedSignal(DataMock)
+    assert signal.message_class is DataMock
 
 
 def test_send_signal_without_data():
@@ -70,16 +71,62 @@ def test_send_robust_signal():
         assert message.required_field == 10
         assert message.__class__ == DataMock
 
-    signal.send_robust(
+    responses = signal.send_robust(
         mock.Mock(),
         DataMock(
             required_field=10,
         ),
     )
 
+    assert all(not isinstance(response, Exception) for _, response in responses)
 
-def test_send_robus_signal_checks_for_wrong_type():
+
+def test_send_robust_signal_checks_for_wrong_type():
     signal = UnifiedSignal(DataMock)
 
     with pytest.raises(UnifiedSignalMessageTypeError):
         signal.send_robust(mock.Mock(), 10)
+
+
+def test_signal_with_use_caching():
+    signal = UnifiedSignal(DataMock, use_caching=True)
+
+    handler = mock.Mock()
+    receiver(signal)(handler)
+
+    signal.send(mock.Mock(), DataMock(required_field=10))
+
+    handler.assert_called_once()
+
+
+def test_send_forwards_extra_kwargs():
+    signal = UnifiedSignal(DataMock)
+    handler = mock.Mock()
+    receiver(signal)(handler)
+
+    signal.send(mock.Mock(), DataMock(required_field=10), extra="value")
+
+    _, kwargs = handler.call_args
+    assert kwargs["extra"] == "value"
+
+
+def test_send_robust_forwards_extra_kwargs():
+    signal = UnifiedSignal(DataMock)
+    handler = mock.Mock()
+    receiver(signal)(handler)
+
+    signal.send_robust(mock.Mock(), DataMock(required_field=10), extra="value")
+
+    _, kwargs = handler.call_args
+    assert kwargs["extra"] == "value"
+
+
+def test_receiver_not_called_on_invalid_message():
+    signal = UnifiedSignal(DataMock)
+    handler = mock.Mock()
+    receiver(signal)(handler)
+
+    with pytest.raises(UnifiedSignalMessageTypeError):
+        signal.send(mock.Mock(), "not a message")
+
+    handler.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands_pre =
     dj6.0: uv pip install "Django>=6.0,<6.1"
 commands =
     uv run python manage.py --version
-    uv run pytest --cov=src/unified_signals tests/
+    uv run pytest --cov=src/unified_signals --cov-report=xml --cov-fail-under=100 tests/
 
 
 [testenv:safety]
@@ -61,4 +61,4 @@ commands =
 
 [testenv:coverage]
 commands =
-    uv run pytest --cov=src/unified_signals tests/
+    uv run pytest --cov=src/unified_signals --cov-report=xml --cov-fail-under=100 tests/


### PR DESCRIPTION
## Summary
- `send_robust()` dropped `message` before calling `super().send_robust()`, so any receiver expecting `message` crashed with `TypeError` (silently, since Django swallows receiver exceptions in `send_robust`)
- Fixed test `test_send_robust_signal` to assert on the response list, catching this class of bug going forward
- Added tests for `use_caching`, extra kwarg forwarding, and receiver-not-called-on-invalid-message
- Added `--cov-fail-under=100` gate and Codecov upload/badge